### PR TITLE
Fix hamcore building with incorrect file size

### DIFF
--- a/Hamcore.c
+++ b/Hamcore.c
@@ -389,7 +389,7 @@ bool HamcoreBuild(const char *dst_path, const char *base_path, const char **src_
 		goto FINAL;
 	}
 
-	if (!Ham_FileWrite(handle, buffer, buffer_size))
+	if (!Ham_FileWrite(handle, buffer, offset))
 	{
 		fprintf(stderr, "HamcoreBuild(): Failed to write \"%s\"!\n", dst_path);
 		goto FINAL;


### PR DESCRIPTION
HamcoreBuild was creating files lager than their actual size. This occurred because buffer_size referred to the size of the buffer allocated during compression, rather than the actual file size(offset). Fix this by specifying the correct file size during the write process.

--- 

This issue affects non-Windows platforms where hamcore.se2 contains fewer files.
For example, on x86_64 Linux, Apply this change,  reduce the output size of hamcore.se2 from  5.24 MB to 2.98 MB.