### PR TITLE
Update CI actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       if: runner.os == 'Windows'
       with:
           key: 'vcpkg-${{matrix.os}}'


### PR DESCRIPTION
The latest CI failures are due to the use of a deprecated version of actions/cache. I will update the version to fix the CI.

<img width="1112" height="634" alt="screenshot-2026-02-25-21-13-14" src="https://github.com/user-attachments/assets/fd70bbda-983e-4176-8a52-4aa228722ea0" />
